### PR TITLE
Replace blacklist with skiplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ genomes:
       checksum: #A SHA256 checksum of the original
       blob: #A blob for any other pertinent information
       indexers: #A list of tags for the types of data managers to be run on this data
-      blacklist: # A list of data managers with the above specified tag NOT to be run on this data
+      skiplist: # A list of data managers with the above specified tag NOT to be run on this data
 
 ```
 
@@ -153,7 +153,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: Ecoli-O157-H7-Sakai
     description: "Escherichia coli O157-H7 Sakai"
@@ -165,7 +165,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: Salm-enterica-Newport
     description: "Salmonella enterica subsp. enterica serovar Newport str. USMARC-S3124.1"
@@ -177,7 +177,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
 ```
 

--- a/genomes.yml
+++ b/genomes.yml
@@ -9,7 +9,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: danRer10
     description: Zebrafish Sep. 2014 (GRCz10/danRer10) (danRer10)
@@ -21,7 +21,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: sacCer3
     description: "Yeast (Saccharomyces cerevisiae): sacCer3"
@@ -33,7 +33,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: Ecoli-O157-H7-Sakai
     description: "Escherichia coli O157-H7 Sakai"
@@ -45,7 +45,7 @@ genomes:
     blob:
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast
   - dbkey: Salm-enterica-Newport
     description: "Salmonella enterica subsp. enterica serovar Newport str. USMARC-S3124.1"
@@ -57,5 +57,5 @@ genomes:
     blob: "Extra information for this genome is at: https://www.ncbi.nlm.nih.gov/genome/152?genome_assembly_id=299243"
     indexers:
       - genome
-    blacklist:
+    skiplist:
       - bfast


### PR DESCRIPTION
Since there is no corresponding 'allowlist' (?) we could alternatively opt for `skip` or similar.